### PR TITLE
修复home-top四按钮宽度错误

### DIFF
--- a/source/css/_page/_home/home-top.styl
+++ b/source/css/_page/_home/home-top.styl
@@ -272,9 +272,7 @@
   color var(--efu-white)
   position relative
   background-size 200%
-
-  &:not(:last-child)
-    margin-right 10px
+  margin-right 10px
 
   &:hover
     background-position 100% 0


### PR DESCRIPTION
### ❓ 修改类型

- [x] 🐞 Bug fix (修复问题的连续性改)
- [ ] 👌 增强功能（改进现有功能，如性能）
- [ ] ✨ Feature（添加功能的连续性修改）
- [ ] ⚠️ 中断修改（重大的修改，如配置文件调整、模块移除）

### 📚 描述

修复home-top跳转按钮为四个时最后一个按钮宽度存在错误的问题