### PR TITLE
修复gallery相册多个时移动端无法自动换行

### DIFF
--- a/source/css/_tags/gallery.styl
+++ b/source/css/_tags/gallery.styl
@@ -96,6 +96,7 @@
     display flex
     gap .5rem
     margin-top .5rem
+    flex-wrap wrap
 
   .gallery-item
     min-height 5rem


### PR DESCRIPTION
### ❓ 修改类型

<!--代码引入了哪些类型的更改？在所有适用的框中放置一个“x”。 -->

- [x] 🐞 Bug fix (修复问题的连续性改)
- [ ] 👌 增强功能（改进现有功能，如性能）
- [ ] ✨ Feature（添加功能的连续性修改）
- [ ] ⚠️ 中断修改（重大的修改，如配置文件调整、模块移除）

### 📚 描述

修复gallery相册配置了多个时移动端无法自动换行，会导致多个相册挤在同一行的问题