### PR TITLE
修复home-top额外添加按钮时出现的对齐问题

### DIFF
--- a/source/css/_page/_home/home-top.styl
+++ b/source/css/_page/_home/home-top.styl
@@ -272,9 +272,7 @@
   color var(--efu-white)
   position relative
   background-size 200%
-
-  &:not(:last-child)
-    margin-right 10px
+  margin-right 10px
 
   &:hover
     background-position 100% 0


### PR DESCRIPTION
### ❓ 修改类型

<!--代码引入了哪些类型的更改？在所有适用的框中放置一个“x”。 -->

- [x] 🐞 Bug fix (修复问题的连续性改)
- [ ] 👌 增强功能（改进现有功能，如性能）
- [ ] ✨ Feature（添加功能的连续性修改）
- [ ] ⚠️ 中断修改（重大的修改，如配置文件调整、模块移除）

### 📚 描述

修复home-top额外添加按钮（按钮超过三个）时出现的对齐问题（防止文字右侧出现异常空白）