### PR TITLE
Update asideNewestPost.pug

### DIFF
--- a/layout/includes/widgets/aside/asideNewestPost.pug
+++ b/layout/includes/widgets/aside/asideNewestPost.pug
@@ -6,11 +6,11 @@
         - let index = 1
         each post in site.posts.data.sort((a, b) => b.date < a.date ? -1 : 1)
             if index <= 5
-                .aside-list-item
-                    a.thumbnail(href=url_for(post.path) title=post.title)
+                a.aside-list-item(href=url_for(post.path) title=post.title)
+                    .thumbnail
                         img(alt=post.title src=url_for(post.cover))
                     .content
-                        span.title(href=url_for(post.path) title=post.title)= post.title
+                        span.title= post.title
                         if post.categories.data[0]
-                            span.article-recent_post_categories(href=url_for(post.path))= post.categories.data[0].name
+                            span.article-recent_post_categories= post.categories.data[0].name
                 - index++


### PR DESCRIPTION
最新发布板块下的文章必须点击图片才能跳转文章，点击文字或者空白区域不能跳转，重写了代码解决问题

### 🔗 链接 issue

最新发布板块下的文章必须点击图片才能跳转文章，点击文字或者空白区域不能跳转

### ❓ 修改类型

<!--代码引入了哪些类型的更改？在所有适用的框中放置一个“x”。 -->

- [x ] 🐞 Bug fix (修复问题的连续性改)
- [x ] 👌 增强功能（改进现有功能，如性能）
- [ ] ✨ Feature（添加功能的连续性修改）
- [ ] ⚠️ 中断修改（重大的修改，如配置文件调整、模块移除）

### 📚 描述

<!-- 详细说明你的更改 -->
重写了pug文件
<!-- 为什么需要此更改？它解决了什么问题？-->
最新发布板块下的文章必须点击图片才能跳转文章，点击文字或者空白区域不能跳转
<!-- 如果它解决了未解决的问题，请在此处链接到该问题。例如，“Resolves #1337” -->
我自己发现的问题，没有提issue
### 📝 清单

<!-- 在所有适用的框中放置一个“x”。 -->
<!-- 如果更改需要文档 PR，请适当地链接它 -->
<!-- 如果不确定其中任何一个，请随时询问。我们是来帮忙的！ -->

- [ ] 我已链接问题或讨论。
- [x ] 我已经添加了测试（如果可能的话）。
- [ ] 我已相应地更新了[文档](https://github.com/everfu/solitude.js.org)。
