### PR TITLE
修复 tabs 标签插件填入 [索引] 参数时未正常选择对应标签块的问题。

### DIFF
--- a/scripts/tags/tabs.js
+++ b/scripts/tags/tabs.js
@@ -14,9 +14,7 @@ function postTabs ([name, active], content) {
   let tabNav = ''
   let tabContent = ''
 
-  if (typeof active === 'undefined') {
-    active = 0
-  }
+  active = Number(active) || 0
 
   while ((match = tabBlock.exec(content)) !== null) {
     matches.push(match[1])


### PR DESCRIPTION
### 🔗 链接 issue

<!-- 请确保存在未解决的问题，将编号提及为 #123（示例） -->

### ❓ 修改类型

<!--代码引入了哪些类型的更改？在所有适用的框中放置一个“x”。 -->

- [x] 🐞 Bug fix (修复问题的连续性改)
- [ ] 👌 增强功能（改进现有功能，如性能）
- [ ] ✨ Feature（添加功能的连续性修改）
- [ ] ⚠️ 中断修改（重大的修改，如配置文件调整、模块移除）

### 📚 描述

<!-- 详细说明你的更改 -->
<!-- 为什么需要此更改？它解决了什么问题？-->
<!-- 如果它解决了未解决的问题，请在此处链接到该问题。例如，“Resolves #1337” -->

修复了 tabs 标签在填入索引时，由于 `active` 变量为 `String` 类型且未转换为数字，导致不会默认选择任何标签的 Bug。

### 📝 清单

<!-- 在所有适用的框中放置一个“x”。 -->
<!-- 如果更改需要文档 PR，请适当地链接它 -->
<!-- 如果不确定其中任何一个，请随时询问。我们是来帮忙的！ -->

- [ ] 我已链接问题或讨论。
- [ ] 我已经添加了测试（如果可能的话）。
- [ ] 我已相应地更新了[文档](https://github.com/everfu/solitude.js.org)。
