### PR TITLE
✨ ctrl + 右键打开浏览器右键菜单；🔥 修复 article 标签 bug

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -882,6 +882,9 @@ right_menu:
   # Whether to display the hot comment switch.
   # 是否显示热门评论开关
   commentBarrage: false
+  # Whether to display the browser's context menu when hold Ctrl key.
+  # 是否在按住 Ctrl 键时显示浏览器右键菜单
+  ctrlOriginalMenu: false
   # Simplified and Traditional Chinese translation.
   # 简繁体转换
   translate:

--- a/languages/default.yml
+++ b/languages/default.yml
@@ -196,6 +196,7 @@ right_menu:
   chs_to_cht: 轉為繁體
   cht_to_chs: 转为简体
   img_error: This image cannot be copied or downloaded.
+  ctrl_original_menu: Hold Ctrl + right-click to open the browser's context menu
   barrage:
     open: Open Barrage
     close: Close Barrage

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -196,6 +196,7 @@ right_menu:
   chs_to_cht: 轉為繁體
   cht_to_chs: 转为简体
   img_error: This image cannot be copied or downloaded.
+  ctrl_original_menu: Hold Ctrl + right-click to open the browser's context menu
   barrage:
     open: Open Barrage
     close: Close Barrage

--- a/languages/zh-CN.yml
+++ b/languages/zh-CN.yml
@@ -196,6 +196,7 @@ right_menu:
   chs_to_cht: 轉為繁體
   cht_to_chs: 转为简体
   img_error: 此图片无法复制与下载
+  ctrl_original_menu: 按住Ctrl+右键可打开浏览器右键菜单
   barrage:
     open: 显示热评
     close: 关闭热评

--- a/languages/zh-TW.yml
+++ b/languages/zh-TW.yml
@@ -194,6 +194,7 @@ right_menu:
   chs_to_cht: 轉為繁體
   cht_to_chs: 转为简体
   img_error: 此圖片無法複製與下載
+  ctrl_original_menu: 按住Ctrl+右鍵可打開瀏覽器右鍵選單
   barrage:
     open: 顯示熱評
     close: 關閉熱評

--- a/layout/includes/head/config.pug
+++ b/layout/includes/head/config.pug
@@ -120,6 +120,8 @@
                 defaultEncoding: theme.right_menu.translate.defaultEncoding
             }
         }
+        if (theme.right_menu.ctrlOriginalMenu)
+            rightMenu.ctrlOriginalMenu = _p('right_menu.ctrl_original_menu')
     }
 
     let highlight = false

--- a/scripts/event/merge_config.js
+++ b/scripts/event/merge_config.js
@@ -383,6 +383,7 @@ hexo.extend.filter.register('before_generate', () => {
     right_menu: {
       enable: false,
       commentBarrage: false,
+      ctrlOriginalMenu: false,
       translate: {
         enable: false,
         defaultEncoding: 2,

--- a/scripts/tags/article.js
+++ b/scripts/tags/article.js
@@ -7,33 +7,12 @@ const article = ([path]) => {
   }
   const tags = post.tags.map(tag => `<a class="article-meta__tags fancybox" href="${tag.path}" onclick="event.stopPropagation();"><span class="tags-punctuation"><i class="solitude fa-solid fa-hashtag"></i>${tag.name}</span></a>`).join('');
   const category = post.categories.data.length > 0 ? `<span class="article-meta sticky-warp"><span class="original">${post.categories.data[0].name}</span></span>` : '';
-  return `
-    <div class="recent-post-item" onclick="pjax.loadUrl('${post.path}')">
-      <div class="post_cover">
-        <a href="${post.path}" class="fancybox" title="${post.title}">
-          <img class="post_bg" src="${post.cover}" alt="${post.title}">
-        </a>
-      </div>
-      <div class="recent-post-info">
-        <div class="recent-post-info-top">
-          <div class="recent-post-info-top-tips">
-            ${category}
-          </div>
-          <a class="article-title fancybox" href="${post.path}" title="${post.title}">${post.title}</a>
-        </div>
-        <div class="content">
-        ${post.description ? post.description : ''}
-        </div>
-        <div class="article-meta-wrap">
-          <span class="article-meta tags">
-            ${tags}
-          </span>
-          <span class="post-meta-date">
-            <time datetime="${post.date}" style="display: inline;"></time>
-          </span>
-        </div>
-      </div>
-    </div>`;
+  const postCover = `<div class="post_cover"><a href="${'/' + post.path}" class="fancybox" title="${post.title}"><img class="post_bg" src="${post.cover}" alt="${post.title}"></a></div>`;
+  const recentPostInfoTop = `<div class="recent-post-info-top"><div class="recent-post-info-top-tips">${category}</div><a class="article-title fancybox" href="${'/' + post.path}" title="${post.title}">${post.title}</a></div>`;
+  const content = `<div class="content">${post.description ? post.description : ''}</div>`;
+  const articleMetaWrap = `<div class="article-meta-wrap"><span class="article-meta tags">${tags}</span><span class="post-meta-date"><time datetime="${post.date}" style="display: inline;"></time></span></div>`;
+  const recentPostInfo = `<div class="recent-post-info">${recentPostInfoTop + content + articleMetaWrap}</div>`
+  return `<div class="recent-post-item" onclick="pjax.loadUrl('${'/' + post.path}')">${postCover + recentPostInfo}</div>`;
 }
 
 hexo.extend.tag.register('article', article)

--- a/source/js/right_menu.js
+++ b/source/js/right_menu.js
@@ -1,4 +1,5 @@
 let selectTextNow = "";
+let firstShowRightMenu = true;
 const selectText = () => {
     selectTextNow = document.selection
         ? document.selection.createRange().text
@@ -106,6 +107,15 @@ function stopMaskScroll() {
 
 window.oncontextmenu = (ele) => {
     if (document.body.clientWidth <= 768) return;
+    if (GLOBAL_CONFIG.right_menu.ctrlOriginalMenu) {
+        if (firstShowRightMenu) {
+            firstShowRightMenu = false;
+            utils.snackbarShow(GLOBAL_CONFIG.right_menu.ctrlOriginalMenu, false, 2000);
+        }
+        if (ele.ctrlKey) {
+            return true;
+        }
+    }
     let x = ele.clientX + 10;
     let y = ele.clientY;
     Array.from(rm.menuItems.other).forEach((item) => (item.style.display = "flex"));


### PR DESCRIPTION
### 🔗 链接 issue

<!-- 请确保存在未解决的问题，将编号提及为 #123（示例） -->

### ❓ 修改类型

<!--代码引入了哪些类型的更改？在所有适用的框中放置一个“x”。 -->

- [x] 🐞 Bug fix (修复问题的连续性改)
- [ ] 👌 增强功能（改进现有功能，如性能）
- [x] ✨ Feature（添加功能的连续性修改）
- [ ] ⚠️ 中断修改（重大的修改，如配置文件调整、模块移除）

### 📚 描述

<!-- 详细说明你的更改 -->
<!-- 为什么需要此更改？它解决了什么问题？-->
<!-- 如果它解决了未解决的问题，请在此处链接到该问题。例如，“Resolves #1337” -->

Feature: 
- 新增了使用 ctrl + 右键打开浏览器原有的右键菜单的功能（默认关闭），便于调试或使用上下文菜单的其他功能。开启该功能时，第一次打开右键菜单会在顶部提示使用 ctrl + 右键可打开浏览器右键菜单。

Bug fix: 
- 修复了 `article` 标签在 `tabs` 标签页的标签块内部使用时，会渲染出源码的问题
- 修复了 `article` 标签指向的链接错误的问题（修复前，当 `article` 标签的 `path` 参数为 `posts/abc/` 时，指向的链接为 `root_url/posts/abc/posts/abc/`，导致跳转到 404 页面）

### 📝 清单

<!-- 在所有适用的框中放置一个“x”。 -->
<!-- 如果更改需要文档 PR，请适当地链接它 -->
<!-- 如果不确定其中任何一个，请随时询问。我们是来帮忙的！ -->

- [ ] 我已链接问题或讨论。
- [x] 我已经添加了测试（如果可能的话）。
- [ ] 我已相应地更新了[文档](https://github.com/everfu/solitude.js.org)。
