### PR TITLE
添加 css 样式以修正 firefox windows 端显示效果

### DIFF
--- a/source/css/_page/_home/category-bar.styl
+++ b/source/css/_page/_home/category-bar.styl
@@ -66,6 +66,7 @@
     border-radius 8px
     align-items center
     height 30px
+    scrollbar-width: none
     +maxWidth768()
       height 44px
       gap 6px


### PR DESCRIPTION
### ❓ 修改类型

<!--代码引入了哪些类型的更改？在所有适用的框中放置一个“x”。 -->

- [x] 🐞 Bug fix (修复问题的连续性改)
- [ ] 👌 增强功能（改进现有功能，如性能）
- [ ] ✨ Feature（添加功能的连续性修改）
- [ ] ⚠️ 中断修改（重大的修改，如配置文件调整、模块移除）

### 📚 描述

<!-- 详细说明你的更改 -->
<!-- 为什么需要此更改？它解决了什么问题？-->
<!-- 如果它解决了未解决的问题，请在此处链接到该问题。例如，“Resolves #1337” -->
![图片](https://github.com/user-attachments/assets/6fca26e1-6d39-43e2-8afd-ff2b23b62e94)
![图片](https://github.com/user-attachments/assets/0560b3ae-b351-4e8f-be3f-02ea28af35ef)

在 Firefox Windows 端浏览时，分类条下方会出现滚动条，导致显示效果不正确。
在 `.category-bar-items` 添加 `scrollbar-width: none;` 后该问题解决。

### 📝 清单

<!-- 在所有适用的框中放置一个“x”。 -->
<!-- 如果更改需要文档 PR，请适当地链接它 -->
<!-- 如果不确定其中任何一个，请随时询问。我们是来帮忙的！ -->

- [ ] 我已链接问题或讨论。
- [x] 我已经添加了测试（如果可能的话）。
- [ ] 我已相应地更新了[文档](https://github.com/everfu/solitude.js.org)。
