### PR TITLE
修复音乐胶囊设置单曲不生效

### DIFF
--- a/layout/includes/widgets/third-party/music.pug
+++ b/layout/includes/widgets/third-party/music.pug
@@ -1,3 +1,3 @@
 div.needEndHide#nav-music
   #nav-music-hoverTips(onclick='sco.musicToggle()')= __('music.hit')
-  meting-js(id=theme.capsule.id server=theme.capsule.server type="playlist" mutex="true" preload="none" theme="var(--efu-main)" data-lrctype="0" order="random" volume=theme.capsule.volume)
+  meting-js(id=theme.capsule.id server=theme.capsule.server type=theme.capsule.type mutex="true" preload="none" theme="var(--efu-main)" data-lrctype="0" order="random" volume=theme.capsule.volume)


### PR DESCRIPTION
### ❓ 修改类型

<!--代码引入了哪些类型的更改？在所有适用的框中放置一个“x”。 -->

- [x] 🐞 Bug fix (修复问题的连续性改)
- [ ] 👌 增强功能（改进现有功能，如性能）
- [ ] ✨ Feature（添加功能的连续性修改）
- [ ] ⚠️ 中断修改（重大的修改，如配置文件调整、模块移除）

### 📚 描述

修复音乐胶囊在配置文件设置模式为单曲时不生效的问题