### PR TITLE
fix: 不蒜子加载 & 文章热度显示逻辑

### DIFF
--- a/layout/includes/inject/body.pug
+++ b/layout/includes/inject/body.pug
@@ -111,7 +111,7 @@ div
     if is_home() && theme.carousel && site.posts.data.filter(item => item.recommend === true).slice(0, 6) || false
       script.
         carousel_swiper()
-    if theme.busuanzi && (theme.aside.siteinfo.uv || theme.aside.siteinfo.pv)
+    if theme.busuanzi && (theme.aside.siteinfo.uv || theme.aside.siteinfo.pv || is_post() && theme.post.meta.pv)
       script(defer pjax src=url_for(theme.cdn.busuanzi_js))
 
 

--- a/layout/includes/widgets/post/postInfo.pug
+++ b/layout/includes/widgets/post/postInfo.pug
@@ -37,7 +37,7 @@
                 span.post-meta-position(title=_p('post.ip') + page.locate)
                     i.post-meta-icon.solitude.fas.fa-location-dot
                     span= page.locate
-            if theme.post.meta.pv
+            if theme.post.meta.pv && (theme.comment.use && theme.comment.pv || theme.busuanzi)
                 a.post-meta-pv(href=url_for(page.path), title=_p('post.pv'))
                     i.post-meta-icon.solitude.fa-solid.fa-fire-flame-curved
                     if theme.comment.use && theme.comment.pv


### PR DESCRIPTION
### 🔗 链接 issue

<!-- 请确保存在未解决的问题，将编号提及为 #123（示例） -->
#442 

### ❓ 修改类型

<!--代码引入了哪些类型的更改？在所有适用的框中放置一个“x”。 -->

- [x] 🐞 Bug fix (修复问题的连续性改)
- [ ] 👌 增强功能（改进现有功能，如性能）
- [ ] ✨ Feature（添加功能的连续性修改）
- [ ] ⚠️ 中断修改（重大的修改，如配置文件调整、模块移除）

### 📚 描述

<!-- 详细说明你的更改 -->
<!-- 为什么需要此更改？它解决了什么问题？-->
<!-- 如果它解决了未解决的问题，请在此处链接到该问题。例如，“Resolves #1337” -->
#442 
修复文章热度相关逻辑：#442 
- 完善加载不蒜子的时机
- 完善显示文章热度显示时机

### 📝 清单

<!-- 在所有适用的框中放置一个“x”。 -->
<!-- 如果更改需要文档 PR，请适当地链接它 -->
<!-- 如果不确定其中任何一个，请随时询问。我们是来帮忙的！ -->

- [x] 我已链接问题或讨论。
- [x] 我已经添加了测试（如果可能的话）。
- [ ] 我已相应地更新了[文档](https://github.com/everfu/solitude.js.org)。
