### PR TITLE
fix(source\js\right_menu.js): 右键菜单未判搜索是否开启

### DIFF
--- a/source/js/right_menu.js
+++ b/source/js/right_menu.js
@@ -123,7 +123,7 @@ window.oncontextmenu = (ele) => {
 
     rm.menuItems.copy.style.display = selectTextNow && window.getSelection() ? "flex" : "none";
     GLOBAL_CONFIG.comment && (rm.menuItems.comment.style.display = selectTextNow && window.getSelection() ? "flex" : "none");
-    GLOBAL_CONFIG.search && (rm.menuItems.search.style.display = selectTextNow && window.getSelection() ? "flex" : "none");
+    rm.menuItems.search && (rm.menuItems.search.style.display = selectTextNow && window.getSelection() ? "flex" : "none");
 
     rm.menuItems.new.style.display = link ? "flex" : "none";
     rm.menuItems.copyLink.style.display = link ? "flex" : "none";

--- a/source/js/right_menu.js
+++ b/source/js/right_menu.js
@@ -123,7 +123,7 @@ window.oncontextmenu = (ele) => {
 
     rm.menuItems.copy.style.display = selectTextNow && window.getSelection() ? "flex" : "none";
     GLOBAL_CONFIG.comment && (rm.menuItems.comment.style.display = selectTextNow && window.getSelection() ? "flex" : "none");
-    rm.menuItems.search.style.display = selectTextNow && window.getSelection() ? "flex" : "none";
+    GLOBAL_CONFIG.search && (rm.menuItems.search.style.display = selectTextNow && window.getSelection() ? "flex" : "none");
 
     rm.menuItems.new.style.display = link ? "flex" : "none";
     rm.menuItems.copyLink.style.display = link ? "flex" : "none";


### PR DESCRIPTION
### 🔗 链接 issue

<!-- 请确保存在未解决的问题，将编号提及为 #123（示例） -->
#461 

### ❓ 修改类型

<!--代码引入了哪些类型的更改？在所有适用的框中放置一个“x”。 -->

- [x] 🐞 Bug fix (修复问题的连续性改)
- [ ] 👌 增强功能（改进现有功能，如性能）
- [ ] ✨ Feature（添加功能的连续性修改）
- [ ] ⚠️ 中断修改（重大的修改，如配置文件调整、模块移除）

### 📚 描述

<!-- 详细说明你的更改 -->
<!-- 为什么需要此更改？它解决了什么问题？-->
<!-- 如果它解决了未解决的问题，请在此处链接到该问题。例如，“Resolves #1337” -->
缺搜索功能开启与否的判断逻辑

### 📝 清单

<!-- 在所有适用的框中放置一个“x”。 -->
<!-- 如果更改需要文档 PR，请适当地链接它 -->
<!-- 如果不确定其中任何一个，请随时询问。我们是来帮忙的！ -->

- [x] 我已链接问题或讨论。
- [x] 我已经添加了测试（如果可能的话）。
- [ ] 我已相应地更新了[文档](https://github.com/everfu/solitude.js.org)。
