### PR TITLE
fix(helper/page.js): 更新 urlNoIndex 函数以使用配置中的 pretty_urls

### DIFF
--- a/scripts/helper/page.js
+++ b/scripts/helper/page.js
@@ -13,5 +13,6 @@ hexo.extend.helper.register('page_description', function () {
 })
 
 hexo.extend.helper.register("urlNoIndex", function (url = null) {
-    return prettyUrls(url || this.url, { trailing_index: false, trailing_html: true });
+    const { config } = this
+    return prettyUrls(url || this.url, config.pretty_urls);
 });


### PR DESCRIPTION
### 🔗 链接 issue

<!-- 请确保存在未解决的问题，将编号提及为 #123（示例） -->
#464 

### ❓ 修改类型

<!--代码引入了哪些类型的更改？在所有适用的框中放置一个“x”。 -->

- [x] 🐞 Bug fix (修复问题的连续性改)
- [ ] 👌 增强功能（改进现有功能，如性能）
- [ ] ✨ Feature（添加功能的连续性修改）
- [ ] ⚠️ 中断修改（重大的修改，如配置文件调整、模块移除）

### 📚 描述

<!-- 详细说明你的更改 -->
<!-- 为什么需要此更改？它解决了什么问题？-->
<!-- 如果它解决了未解决的问题，请在此处链接到该问题。例如，“Resolves #1337” -->

#464 urlNoIndex 生成规范网址时，参数写死而不采用站点设定

### 📝 清单

<!-- 在所有适用的框中放置一个“x”。 -->
<!-- 如果更改需要文档 PR，请适当地链接它 -->
<!-- 如果不确定其中任何一个，请随时询问。我们是来帮忙的！ -->

- [x] 我已链接问题或讨论。
- [x] 我已经添加了测试（如果可能的话）。
- [ ] 我已相应地更新了[文档](https://github.com/everfu/solitude.js.org)。
