### PR TITLE
fix: 补全字体回退族名，统一回退到无衬线字体

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -380,7 +380,7 @@ font:
   code-font-size: 16px
   # Global font
   # 全局字体
-  font-family: "PingFang SC, Hiragino Sans GB, Microsoft YaHei"
+  font-family: "PingFang SC, Hiragino Sans GB, Microsoft YaHei, sans-serif"
   # Code font
   # 代码字体
   code-font-family: '"monospace", monospace'

--- a/scripts/event/merge_config.js
+++ b/scripts/event/merge_config.js
@@ -327,7 +327,7 @@ hexo.extend.filter.register('before_generate', () => {
     font: {
       'font-size': '16px',
       'code-font-size': '16px',
-      'font-family': 'PingFang SC, Hiragino Sans GB,Microsoft YaHei',
+      'font-family': 'PingFang SC, Hiragino Sans GB,Microsoft YaHei, sans-serif',
       'code-font-family': '"monospace", monospace',
     },
     extends: {


### PR DESCRIPTION
### 🔗 链接 issue

<!-- 请确保存在未解决的问题，将编号提及为 #123（示例） -->
#480 

### ❓ 修改类型

<!--代码引入了哪些类型的更改？在所有适用的框中放置一个“x”。 -->

- [x] 🐞 Bug fix (修复问题的连续性改)
- [ ] 👌 增强功能（改进现有功能，如性能）
- [ ] ✨ Feature（添加功能的连续性修改）
- [ ] ⚠️ 中断修改（重大的修改，如配置文件调整、模块移除）

### 📚 描述

<!-- 详细说明你的更改 -->
<!-- 为什么需要此更改？它解决了什么问题？-->
<!-- 如果它解决了未解决的问题，请在此处链接到该问题。例如，“Resolves #1337” -->

https://developer.mozilla.org/zh-CN/docs/Web/CSS/font-family

> 应当至少在使用的 font-family 列表中添加一个通用的字体族名，因为无法保证用户的计算机内已经安装了指定的字体，也不能保证使用 [@font-face](https://developer.mozilla.org/zh-CN/docs/Web/CSS/@font-face) 提供的字体移动能够正确地下载。提供通用的字体族使得浏览器可以在无法得到最佳字体的情况下使用一个相对接近的备选字体。

[Microsoft YaHei 字体信息](https://support.microsoft.com/zh-cn/topic/%E5%AD%97%E4%BD%93%E4%BF%A1%E6%81%AF-943ba11e-4cfc-40cf-91fc-206c1f12c760)

[Hiragino Sans 字体信息](https://en.morisawa.co.jp/fonts/specimen/7320)

[Pingfang 介绍 - Wikipedia](https://zh.wikipedia.org/wiki/%E8%8B%B9%E6%96%B9)

上述预设均为无衬线字体，故设定 sans-serif

### 📝 清单

<!-- 在所有适用的框中放置一个“x”。 -->
<!-- 如果更改需要文档 PR，请适当地链接它 -->
<!-- 如果不确定其中任何一个，请随时询问。我们是来帮忙的！ -->

- [x] 我已链接问题或讨论。
- [x] 我已经添加了测试（如果可能的话）。
- [x] 我已相应地更新了[文档](https://github.com/everfu/solitude.js.org)。
