### PR TITLE
ci: 更新 npm 发布流程

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,29 +1,20 @@
-# .github/workflows/release.yml
-
-name: Release
-
-permissions:
-  contents: write
+name: Node.js Package
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [created]
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
-
-      - name: Set node
-        uses: actions/setup-node@v4
+          token: ${{ secrets.ACCESS_TOKEN }}
+      - uses: actions/setup-node@v2
         with:
-          registry-url: https://registry.npmjs.org/
-          node-version: lts/*
-
-      - run: npx changelogithub # or changelogithub@0.12 if ensure the stable result
+          node-version: '14'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm publish
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+# .github/workflows/release.yml
+
+name: Release
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set node
+        uses: actions/setup-node@v4
+        with:
+          registry-url: https://registry.npmjs.org/
+          node-version: lts/*
+
+      - run: npx changelogithub # or changelogithub@0.12 if ensure the stable result
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
- 修改工作流名称为 "Node.js Package"
- 将触发条件改为 release 创建时
- 更新 actions/checkout 版本为 v2
- 移除设置 node 步骤中的 registry-url
- 简化 npm publish 步骤并使用 NODE_AUTH_TOKEN 环境变量

### 🔗 链接 issue

<!-- 请确保存在未解决的问题，将编号提及为 #123（示例） -->

### ❓ 修改类型

<!--代码引入了哪些类型的更改？在所有适用的框中放置一个“x”。 -->

- [ ] 🐞 Bug fix (修复问题的连续性改)
- [ ] 👌 增强功能（改进现有功能，如性能）
- [ ] ✨ Feature（添加功能的连续性修改）
- [ ] ⚠️ 中断修改（重大的修改，如配置文件调整、模块移除）

### 📚 描述

<!-- 详细说明你的更改 -->
<!-- 为什么需要此更改？它解决了什么问题？-->
<!-- 如果它解决了未解决的问题，请在此处链接到该问题。例如，“Resolves #1337” -->

### 📝 清单

<!-- 在所有适用的框中放置一个“x”。 -->
<!-- 如果更改需要文档 PR，请适当地链接它 -->
<!-- 如果不确定其中任何一个，请随时询问。我们是来帮忙的！ -->

- [ ] 我已链接问题或讨论。
- [ ] 我已经添加了测试（如果可能的话）。
- [ ] 我已相应地更新了[文档](https://github.com/everfu/solitude.js.org)。
