### PR TITLE
fix(asideSwitch): 侧边栏组件设定缺省时不应加载页面内容

### DIFF
--- a/layout/includes/widgets/aside/asideSwitch.pug
+++ b/layout/includes/widgets/aside/asideSwitch.pug
@@ -15,5 +15,3 @@ case item
         - const custom = site.data?.aside?.find((i) => i.name === item)
         if custom
             include ./asideCustom.pug
-        else
-            include ../../page/default.pug


### PR DESCRIPTION
fix #520 