### PR TITLE
首页即刻说说滚动条样式优化

### DIFF
--- a/source/css/_page/brevity.styl
+++ b/source/css/_page/brevity.styl
@@ -349,7 +349,6 @@ if hexo-config('brevity.enable')
       text-overflow ellipsis
       transition .3s
       display flex
-      justify-content center
       align-items center
       font-weight 700
       margin auto

--- a/source/css/_page/brevity.styl
+++ b/source/css/_page/brevity.styl
@@ -348,7 +348,6 @@ if hexo-config('brevity.enable')
       overflow hidden
       text-overflow ellipsis
       transition .3s
-      display flex
       align-items center
       font-weight 700
       margin auto


### PR DESCRIPTION
1. 移除即刻说说子元素水平居中，以解决当文本长度超出屏幕显示范围时，无法看到该说说内容开头部分（即只显示正中心文本）的问题
2. 解决因display:flex导致的文本溢出时应显示在文本末尾的省略号无法正常触发的问题