### PR TITLE
修复某个人心血来潮毁掉的我的修复成果

### DIFF
--- a/source/css/_tags/gallery.styl
+++ b/source/css/_tags/gallery.styl
@@ -95,6 +95,7 @@
     display flex
     gap .5rem
     margin-top .5rem
+    flex-wrap wrap
 
   .gallery-item
     min-height 5rem

--- a/source/css/_tags/tabs.styl
+++ b/source/css/_tags/tabs.styl
@@ -10,6 +10,7 @@
     margin-bottom .5rem
     padding .3rem .5rem
     gap .5rem
+    flex-wrap wrap
 
     .tab
       border-radius 6px


### PR DESCRIPTION
我那是修的bug啊！那不是屎山别看啥都删！删了不正常了！

- 再次修复多个相册移动端会被压缩成一根棍子的问题
- 修复tab按钮较多时（按钮数量≥9）因不会自动换行导致的第9号按钮文字溢出，9号以上按钮无法显示的问题