### PR TITLE
多内容修复与完善

### DIFF
--- a/source/css/_components/rightside.styl
+++ b/source/css/_components/rightside.styl
@@ -27,13 +27,13 @@
 
     &.pc
       display: block
-      +maxWidth900()
+      +maxWidth1200()
         display: none
 
     &.mobile
       display: none
 
-      +maxWidth900()
+      +maxWidth1200()
         display: block
 
     &.top

--- a/source/css/_layout/aside.styl
+++ b/source/css/_layout/aside.styl
@@ -3,6 +3,7 @@
   flex-direction column
   gap var(--gap)
   animation slide-in .6s .3s backwards
+  z-index 10
 
   .hide-aside &
     display none

--- a/source/css/_page/index.styl
+++ b/source/css/_page/index.styl
@@ -29,11 +29,8 @@ if hexo-config('google_adsense.enable')
 @import "message"
 
 #page h1.page-title
-  display inline
-  margin .4rem 0 1rem
-  +maxWidth768()
-    display block
-    text-align center
+  margin .4rem 1rem 1rem
+  text-align center
 
 #page
   background 0 0


### PR DESCRIPTION
1. 同步Heo样式，page页h1居中，实现#555 需求
2. aside增加父元素z-index，解决移动端目录与代码高亮溢出条显示层级错误的问题
3. 修复当页面宽度介于900-1200之间（无侧边栏）时，rightside按钮部分不显示文章目录按钮（进而导致无法查看文章目录）的问题