### PR TITLE
修复因未指定元素内容导致的打赏时间缺失问题

### DIFF
--- a/layout/includes/widgets/page/about/award.pug
+++ b/layout/includes/widgets/page/about/award.pug
@@ -18,7 +18,7 @@ if site.data.about.rewardList && site.data.about.award.enable
                                 if reward.icon
                                     i.solitude(class=reward.icon)
                                 | ¥ #{reward.money}
-                            time.datetime.reward-list-item-time(datetime=moment(reward.time).format())
+                            time.datetime.reward-list-item-time(datetime=moment(reward.time).format())= moment(reward.time).format('YYYY-MM-DD')
                 if theme.post.award.enable
                     .post-reward
                         .post-reward(onclick="AddRewardMask()")


### PR DESCRIPTION
原代码只会创建属性，不会生成元素内容，需指定元素实际内容