### PR TITLE
feat: 添加即刻短文图片的描述

### DIFF
--- a/layout/includes/page/brevity.pug
+++ b/layout/includes/page/brevity.pug
@@ -20,7 +20,10 @@ if theme.brevity.enable
                             if item.image
                                 .bber-content-img
                                     each img in item.image
-                                        img(src=img alt="image")
+                                        if typeof img === 'string'
+                                            img(src=img, alt=item.content || "图片暂无描述")
+                                        else
+                                            img(src=img.url, alt=(img.alt || item.content || "图片暂无描述"))
 
                         if item.aplayer
                             .bber-music


### PR DESCRIPTION
添加即刻短文图片的描述，适用两种形式
```yaml
# 原来的方法，alt默认返回content的内容
  image:
    - https://images.com/test.com
# 自定义方法,，alt返回自定义内容
    image:
      - url: https://images.com/test.com
        alt: 描述内容
```
[效果展示](https://blog.418121.xyz/essay/)
修改前
![image](https://github.com/user-attachments/assets/b53f7092-d478-4b6a-bc74-988fa3a9eda2)
修改后
![image](https://github.com/user-attachments/assets/cc65a9d8-4d1b-4fba-8b08-0252409bbd33)
